### PR TITLE
[#6] 간단 로그인 기능 및 데이터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/bookstore/readme/domain/member/api/MemberApi.java
+++ b/src/main/java/com/bookstore/readme/domain/member/api/MemberApi.java
@@ -3,6 +3,7 @@ package com.bookstore.readme.domain.member.api;
 import com.bookstore.readme.domain.member.application.MemberService;
 import com.bookstore.readme.domain.member.dto.MemberDto;
 import com.bookstore.readme.domain.member.dto.MemberJoinDto;
+import com.bookstore.readme.domain.member.dto.MemberLoginDto;
 import com.bookstore.readme.domain.member.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,11 @@ public class MemberApi {
     @PostMapping("/sign-up")
     public ResponseEntity<MemberResponse> save(@RequestBody MemberJoinDto memberJoinDto) {
         return ResponseEntity.ok(memberService.memberJoin(memberJoinDto));
+    }
+
+    @PostMapping("/sign-in")
+    public ResponseEntity<MemberResponse> login(@RequestBody MemberLoginDto memberLoginDto) {
+        return ResponseEntity.ok(memberService.memberLogin(memberLoginDto));
     }
 
 }

--- a/src/main/java/com/bookstore/readme/domain/member/application/MemberQueryService.java
+++ b/src/main/java/com/bookstore/readme/domain/member/application/MemberQueryService.java
@@ -2,10 +2,13 @@ package com.bookstore.readme.domain.member.application;
 
 import com.bookstore.readme.domain.member.domain.Member;
 import com.bookstore.readme.domain.member.dto.MemberJoinDto;
+import com.bookstore.readme.domain.member.dto.MemberLoginDto;
 import com.bookstore.readme.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -19,5 +22,11 @@ public class MemberQueryService {
 
         log.debug("Save Member Entity: {}", entity);
         return true;
+    }
+
+    public Member login(MemberLoginDto memberLoginDto) {
+        Member member = memberRepository.findByEmailAndPassword(memberLoginDto.getEmail(), memberLoginDto.getPassword()).orElse(null);
+        System.out.println("member = " + member);
+        return member;
     }
 }

--- a/src/main/java/com/bookstore/readme/domain/member/application/MemberService.java
+++ b/src/main/java/com/bookstore/readme/domain/member/application/MemberService.java
@@ -1,6 +1,8 @@
 package com.bookstore.readme.domain.member.application;
 
+import com.bookstore.readme.domain.member.domain.Member;
 import com.bookstore.readme.domain.member.dto.MemberJoinDto;
+import com.bookstore.readme.domain.member.dto.MemberLoginDto;
 import com.bookstore.readme.domain.member.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,16 @@ public class MemberService {
                 .status(200)
                 .message("Success")
                 .data(save)
+                .build();
+    }
+
+    public MemberResponse memberLogin(MemberLoginDto memberLoginDto) {
+        Member member = memberQueryService.login(memberLoginDto);
+        return MemberResponse
+                .builder()
+                .status(200)
+                .message("Login Success")
+                .data(member)
                 .build();
     }
 }

--- a/src/main/java/com/bookstore/readme/domain/member/domain/Member.java
+++ b/src/main/java/com/bookstore/readme/domain/member/domain/Member.java
@@ -1,19 +1,18 @@
 package com.bookstore.readme.domain.member.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
-@ToString
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Member {
     @Id
     @GeneratedValue
@@ -29,6 +28,7 @@ public class Member {
     @Column(unique = true)
     private String email;
 
+    @JsonIgnore
     private String password;
 
     @Builder

--- a/src/main/java/com/bookstore/readme/domain/member/dto/MemberLoginDto.java
+++ b/src/main/java/com/bookstore/readme/domain/member/dto/MemberLoginDto.java
@@ -1,0 +1,12 @@
+package com.bookstore.readme.domain.member.dto;
+
+import com.bookstore.readme.domain.member.domain.Member;
+import lombok.Data;
+
+@Data
+public class MemberLoginDto {
+
+    private String email;
+    private String password;
+
+}


### PR DESCRIPTION
- JPA로 가입한 아이디에 해당하는 정보로 findBy 쿼리를 통해 찾아 리턴하는 형식을 구현했다.
- 이 후 Security 적용 후 url 구분을 지어야한다.

#6 