### PR TITLE
fix: 소셜 로그인 회원가입 플로우 수정

### DIFF
--- a/src/main/java/com/bookstore/readme/domain/social/domain/authcode/KakaoAuthCodeRequestUrlProvider.java
+++ b/src/main/java/com/bookstore/readme/domain/social/domain/authcode/KakaoAuthCodeRequestUrlProvider.java
@@ -25,7 +25,7 @@ public class KakaoAuthCodeRequestUrlProvider implements AuthCodeRequestUrlProvid
                 .queryParam("response_type", "code")
                 .queryParam("client_id", kakaoOauthConfig.clientId())
                 .queryParam("redirect_uri", kakaoOauthConfig.redirectUri())
-                .queryParam("scope", String.join(" ", kakaoOauthConfig.scope()))
+                .queryParam("scope", String.join(",", kakaoOauthConfig.scope()))
                 .toUriString();
     }
 }

--- a/src/main/java/com/bookstore/readme/domain/social/domain/authcode/NaverAuthCodeRequestUrlProvider.java
+++ b/src/main/java/com/bookstore/readme/domain/social/domain/authcode/NaverAuthCodeRequestUrlProvider.java
@@ -25,7 +25,7 @@ public class NaverAuthCodeRequestUrlProvider implements AuthCodeRequestUrlProvid
                 .queryParam("response_type", "code")
                 .queryParam("client_id", naverOauthConfig.clientId())
                 .queryParam("redirect_uri", naverOauthConfig.redirectUri())
-                .queryParam("scope", String.join(" ", naverOauthConfig.scope()))
+                .queryParam("scope", String.join(",", naverOauthConfig.scope()))
                 .queryParam("state", "samplestate") // 나중에 수정 작업(인코딩?)
                 .toUriString();
     }

--- a/src/main/java/com/bookstore/readme/domain/social/dto/KakaoTokenDto.java
+++ b/src/main/java/com/bookstore/readme/domain/social/dto/KakaoTokenDto.java
@@ -7,7 +7,6 @@ import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString
 public class KakaoTokenDto {
 
     private String token_type;

--- a/src/main/java/com/bookstore/readme/domain/social/infra/kakao/KakaoApiClient.java
+++ b/src/main/java/com/bookstore/readme/domain/social/infra/kakao/KakaoApiClient.java
@@ -17,7 +17,7 @@ public interface KakaoApiClient {
     @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     KakaoTokenDto fetchToken(@RequestParam MultiValueMap<String, String> params);
 
-    @GetExchange("https://kapi.kako.com/v2/user/me")
+    @GetExchange("https://kapi.kakao.com/v2/user/me")
     KakaoMemberResponseDto fetchMember(@RequestHeader(name = HttpHeaders.AUTHORIZATION) String accessToken);
 
 }

--- a/src/main/java/com/bookstore/readme/domain/social/service/SocialService.java
+++ b/src/main/java/com/bookstore/readme/domain/social/service/SocialService.java
@@ -34,17 +34,17 @@ public class SocialService {
                 .orElseGet(() -> this.socialSave(socialMember));
 
         String accessToken = jwtTokenService.createAccessToken(member.getEmail());
-        String refreshToken = jwtTokenService.createRefreshToken(member.getEmail());
 
         return SocialLoginResponseDto.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .refreshToken(member.getRefreshToken())
                 .build();
     }
 
     private Member socialSave(Member socialMember) {
+        String refreshToken = jwtTokenService.createRefreshToken(socialMember.getEmail());
 
         Member saved = Member.builder()
                 .name(socialMember.getName())
@@ -53,6 +53,7 @@ public class SocialService {
                 .email(socialMember.getEmail())
                 .role(MemberRole.USER)
                 .socialId(socialMember.getSocialId())
+                .refreshToken(refreshToken)
                 .build();
 
         return memberRepository.save(saved);


### PR DESCRIPTION
- 소셜 로그인 (카카오) 완료, 다만 세션 문제인지 기본 창에서는 로그인 불가 / 시크릿 창으로는 확인 후 완료
- 소셜 회원가입 시 RefreshToken DB 저장 플로우 추가

#88 